### PR TITLE
Setup `*.churchfeed.dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@
 
 # misc
 .DS_Store
-*.pem
 
 # debug
 npm-debug.log*
@@ -39,3 +38,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# certs
+*.pem
+Caddyfile

--- a/app/components/Feed.tsx
+++ b/app/components/Feed.tsx
@@ -68,7 +68,11 @@ export default function Feed({ orgId }: FeedProps) {
   return (
     <>
       <div className={styles.feedSelectorWrapper}>
-        <FeedSelector selectedFeedId={feedId} setSelectedFeedId={setFeedId} />
+        <FeedSelector
+          orgId={orgId}
+          selectedFeedId={feedId}
+          setSelectedFeedId={setFeedId}
+        />
       </div>
       <div className={styles.feedWrapper}>
         <h2 className={styles.feedIntro}>What&apos;s happening?</h2>

--- a/app/components/FeedSelector.tsx
+++ b/app/components/FeedSelector.tsx
@@ -10,14 +10,16 @@ import classNames from "classnames";
 export default function FeedSelector({
   selectedFeedId,
   setSelectedFeedId,
+  orgId,
 }: {
   selectedFeedId: Id<"feeds"> | "all";
   setSelectedFeedId: (feedId: Id<"feeds"> | "all") => void;
+  orgId: Id<"organizations">;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const feeds =
     useQuery(api.feeds.getPublicFeeds, {
-      orgId: "j9741k251gw6wwt80s9vq3agfd7erh7s" as Id<"organizations">,
+      orgId,
     }) || [];
 
   const selectedFeed =

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -7,7 +7,7 @@ import Feed from "./Feed";
 import { motion } from "framer-motion";
 
 export default function Home(props: {
-  preloadedOrg: Preloaded<typeof api.organizations.getOrganization>;
+  preloadedOrg: Preloaded<typeof api.organizations.getOrganizationBySubdomain>;
 }) {
   const org = usePreloadedQuery(props.preloadedOrg);
 

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -11,6 +11,10 @@ export default function Home(props: {
 }) {
   const org = usePreloadedQuery(props.preloadedOrg);
 
+  if (org === null) {
+    return <div>No organization found</div>;
+  }
+
   return (
     <div className={styles.feedWrapper}>
       <h1 className={styles.mainTitle}>{org?.name}</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,9 +13,5 @@ export default async function App() {
     }
   );
 
-  return orgSubdomain ? (
-    <Home preloadedOrg={preloadedOrg} />
-  ) : (
-    <div>No organization found</div>
-  );
+  return <Home preloadedOrg={preloadedOrg} />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,21 @@
 import { preloadQuery } from "convex/nextjs";
 import { api } from "../convex/_generated/api";
+import { headers } from "next/headers";
 import Home from "./components/Home";
 
 export default async function App() {
-  const preloadedOrg = await preloadQuery(api.organizations.getOrganization);
+  const orgSubdomain = (await headers()).get("x-org-host") || "";
 
-  return <Home preloadedOrg={preloadedOrg} />;
+  const preloadedOrg = await preloadQuery(
+    api.organizations.getOrganizationBySubdomain,
+    {
+      subdomain: orgSubdomain,
+    }
+  );
+
+  return orgSubdomain ? (
+    <Home preloadedOrg={preloadedOrg} />
+  ) : (
+    <div>No organization found</div>
+  );
 }

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -1,8 +1,14 @@
 import { query } from "./_generated/server";
+import { v } from "convex/values";
 
-export const getOrganization = query({
-  args: {},
-  handler: async (ctx) => {
-    return await ctx.db.query("organizations").first();
+export const getOrganizationBySubdomain = query({
+  args: {
+    subdomain: v.string(),
+  },
+  handler: async (ctx, { subdomain }) => {
+    const host = `${subdomain}.${process.env.HOST}`;
+    return await ctx.db.query("organizations")
+      .withIndex("by_host", (q) => q.eq("host", host))
+      .first();
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14,7 +14,7 @@ export default defineSchema({
     location: v.string(),
     host: v.string(),
     updatedAt: v.number(),
-  }),
+  }).index("by_host", ["host"]),
   feeds: defineTable({
     ...defaultColumns,
     name: v.string(),

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,26 @@
 import { convexAuthNextjsMiddleware } from "@convex-dev/auth/nextjs/server";
+import { type NextRequest, NextResponse } from "next/server";
 
-export default convexAuthNextjsMiddleware();
+const DEFAULT_DOMAIN = process.env.HOST || "";
+
+export default convexAuthNextjsMiddleware((async (request: NextRequest) => {
+  const response = NextResponse.next();
+  const host = request.headers.get("host") || DEFAULT_DOMAIN;
+  const orgSubdomain = getOrgSubdomain(host);
+  response.headers.set("x-org-host", orgSubdomain || "");
+  return response;
+}));
 
 export const config = {
   // The following matcher runs middleware on all routes
   // except static assets.
   matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
 };
+
+function getOrgSubdomain(host: string) {
+  const parts = host.split(".");
+  if (parts.length < 3 || parts[0] === "www") {
+    return null;
+  }
+  return parts[0];
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "setup:local": "npm run setup:certs && npm run setup:dns && npm run setup:caddy",
+    "setup:certs": "node scripts/setup-certs.js",
+    "setup:dns": "node scripts/setup-dns.js",
+    "setup:caddy": "node scripts/setup-caddy.js",
+    "dev": "caddy start --config Caddyfile && npm run dev:nextjs",
+    "dev:stop": "caddy stop",
+    "dev:nextjs": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/scripts/setup-caddy.js
+++ b/scripts/setup-caddy.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+console.log('Setting up Caddy reverse proxy...');
+
+try {
+  // Check if Caddy is available
+  execSync('caddy version', { stdio: 'pipe' });
+
+  // Create Caddyfile with correct certificate names
+  const caddyfile = `
+*.churchfeed.dev {
+    tls ./_wildcard.churchfeed.dev+1.pem ./_wildcard.churchfeed.dev+1-key.pem
+    reverse_proxy localhost:3000
+}
+
+churchfeed.dev {
+    tls ./_wildcard.churchfeed.dev+1.pem ./_wildcard.churchfeed.dev+1-key.pem
+    reverse_proxy localhost:3000
+}
+`;
+
+  fs.writeFileSync('Caddyfile', caddyfile.trim());
+  console.log('✅ Caddy setup complete');
+} catch (error) {
+  console.error('❌ Caddy not found. Please install Caddy first.');
+  process.exit(1);
+}

--- a/scripts/setup-certs.js
+++ b/scripts/setup-certs.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+console.log('Setting up SSL certificates...');
+
+try {
+  // Check if mkcert is available
+  execSync('mkcert -version', { stdio: 'pipe' });
+
+  // Install CA if not already done
+  execSync('mkcert -install', { stdio: 'inherit' });
+  
+  // Check if certificates already exist
+  if (fs.existsSync('_wildcard.churchfeed.dev.pem')) {
+    console.log('Certificates already exist');
+  } else {
+    execSync('mkcert "*.churchfeed.dev" churchfeed.dev', { stdio: 'inherit' });
+    console.log('Generated new certificates');
+  }
+  
+  console.log('✅ SSL certificates ready');
+} catch (error) {
+  console.error('❌ mkcert not found. Please install mkcert first.');
+  process.exit(1);
+}

--- a/scripts/setup-dns.js
+++ b/scripts/setup-dns.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { execSync } = require('child_process');
+const os = require('os');
+
+console.log('Setting up local DNS for *.churchfeed.dev...');
+
+if (os.platform() === 'darwin') {
+  try {
+    // Check if dnsmasq is available
+    execSync('brew list dnsmasq', { stdio: 'pipe' });
+    
+    // Configure dnsmasq
+    const dnsmasqConf = '/opt/homebrew/etc/dnsmasq.conf';
+    const config = 'address=/churchfeed.dev/127.0.0.1\n';
+    
+    if (fs.existsSync(dnsmasqConf)) {
+      const currentConfig = fs.readFileSync(dnsmasqConf, 'utf8');
+      if (!currentConfig.includes('churchfeed.dev')) {
+        fs.appendFileSync(dnsmasqConf, config);
+        console.log('Added churchfeed.dev to dnsmasq config');
+      } else {
+        console.log('dnsmasq already configured for churchfeed.dev');
+      }
+    } else {
+      fs.writeFileSync(dnsmasqConf, config);
+      console.log('Created dnsmasq config');
+    }
+    
+    // Start dnsmasq
+    execSync('sudo brew services start dnsmasq', { stdio: 'inherit' });
+    
+    // Add resolver with sudo
+    execSync('sudo mkdir -p /etc/resolver', { stdio: 'inherit' });
+    
+    // Check if resolver already exists
+    if (!fs.existsSync('/etc/resolver/churchfeed.dev')) {
+      execSync('echo "nameserver 127.0.0.1" | sudo tee /etc/resolver/churchfeed.dev', { stdio: 'inherit' });
+      console.log('Created DNS resolver');
+    } else {
+      console.log('DNS resolver already exists');
+    }
+    
+    console.log('✅ DNS setup complete for macOS');
+  } catch (error) {
+    console.error('❌ dnsmasq not found. Please install dnsmasq first.');
+    process.exit(1);
+  }
+} else {
+  console.log('⚠️  Manual DNS setup required for your OS');
+  console.log('Add these entries to /etc/hosts:');
+  console.log('127.0.0.1 churchfeed.dev');
+  console.log('127.0.0.1 *.churchfeed.dev');
+}


### PR DESCRIPTION
Closes [#5](https://github.com/NolanPic/churchfeed/issues/5)

This introduces development via churchfeed.dev, e.g. `someorg.churchfeed.dev`. Any subdomain that exists in the db will work.

Now, before running `npm run dev` you will run `npm run setup:local` which will run the necessary scripts for setting up the local dns and caddy for SSL. The scripts were mainly written by Claude as a first-pass.

Feeds are now loaded based on the `orgId`, which in turn is received from getting the org based on the subdomain.