### PR TITLE
Orders posts by `postedAt`

### DIFF
--- a/convex/posts.ts
+++ b/convex/posts.ts
@@ -27,7 +27,7 @@ export const getPublicFeedPosts = query({
 
     const posts = await cxt.db
       .query("posts")
-      .withIndex("by_org", (q) =>
+      .withIndex("by_org_and_postedAt", (q) =>
         q.eq("orgId", orgId),
       )
       .filter((q) => q.or(...feedIds.map(id => q.eq(q.field("feedId"), id))))

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -43,7 +43,7 @@ export default defineSchema({
     posterId: v.id("users"),
     content: v.string(),
     postedAt: v.optional(v.number()),
-  }).index("by_org", ["orgId"]),
+  }).index("by_org_and_postedAt", ["orgId", "postedAt"]),
   messages: defineTable({
     ...defaultColumns,
     postId: v.id("posts"),


### PR DESCRIPTION
Follow-up to https://github.com/NolanPic/churchfeed/pull/21

Orders posts by `postedAt` so they show in the correct order in the feed.