### PR TITLE
Update FeedSelector.module.css

### DIFF
--- a/app/components/FeedSelector.module.css
+++ b/app/components/FeedSelector.module.css
@@ -70,6 +70,7 @@
         width: 0;
         height: 0;
         overflow: hidden;
+        visibility: hidden;
     }
 }
 


### PR DESCRIPTION
Hides radio buttons from feed selector dropdown menu on Safari

Closes [#24](https://github.com/NolanPic/churchfeed/issues/24)