### PR TITLE
Allow faking a subdomain on localhost

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,12 +2,13 @@ import { convexAuthNextjsMiddleware } from "@convex-dev/auth/nextjs/server";
 import { type NextRequest, NextResponse } from "next/server";
 
 const DEFAULT_DOMAIN = process.env.HOST || "";
+const MOCK_SUBDOMAIN_FOR_LOCALHOST = process.env.MOCK_SUBDOMAIN_FOR_LOCALHOST || "";
 
 export default convexAuthNextjsMiddleware((async (request: NextRequest) => {
   const response = NextResponse.next();
   const host = request.headers.get("host") || DEFAULT_DOMAIN;
   const orgSubdomain = getOrgSubdomain(host);
-  response.headers.set("x-org-host", orgSubdomain || "");
+  response.headers.set("x-org-host", orgSubdomain || MOCK_SUBDOMAIN_FOR_LOCALHOST || "");
   return response;
 }));
 


### PR DESCRIPTION
Safari is not liking our local non-registered domain (churchfeed.dev). A more comprehensive solution is needed to make it work (maybe buying the domain), but in the meantime it should be possible to fake the subdomain when using localhost.

To test, set `MOCK_SUBDOMAIN_FOR_LOCALHOST` in your `.env` file to an org subdomain, e.g. `kingscross`.