### PR TITLE
Fail auth for queries if user is deactivated

### DIFF
--- a/convex/user.ts
+++ b/convex/user.ts
@@ -5,7 +5,7 @@ import { v } from "convex/values";
 
 export type AuthResult<T = any> = 
   | { success: true; clerkUser: UserIdentity; user: Doc<"users">; data?: T }
-  | { success: false; reason: 'unauthenticated' | 'user_not_found' | 'unauthorized' };
+| { success: false; reason: 'unauthenticated' | 'user_not_found' | 'unauthorized' | 'user_deactivated' };
 
 type AuthContext = QueryCtx | MutationCtx;
 
@@ -82,6 +82,10 @@ export const getAuthResult = async (
 
   if (!user) {
     return { success: false, reason: 'user_not_found' };
+  }
+
+  if(user.deactivatedAt) {
+    return { success: false, reason: 'user_deactivated' };
   }
 
   return { success: true, clerkUser, user };


### PR DESCRIPTION
While a user cannot log in after they are deactivated, they can still be logged in at the time of deactivation. This PR ensures they are treated as unauthenticated in query calls. 

User will be fully logged out when deactivated in https://github.com/NolanPic/churchfeed/issues/52.