### PR TITLE
Ensure that the user exists when checking `isSignedIn`

### DIFF
--- a/app/hooks/useAuthedUser.ts
+++ b/app/hooks/useAuthedUser.ts
@@ -40,13 +40,12 @@ export const useAuthedUser = () => {
     feedsWithMemberships.push({ ...feed, owner: userFeed?.owner ?? false });
   }
 
-
   return {
     user,
     clerkUser,
     organization: org,
-    isSignedIn,
-    isLoaded,
+    isSignedIn: isSignedIn && !!user,
+    isLoaded: isLoaded && !!user,
     signOut,
     feeds: feedsWithMemberships,
   };

--- a/app/hooks/useAuthedUser.ts
+++ b/app/hooks/useAuthedUser.ts
@@ -45,7 +45,7 @@ export const useAuthedUser = () => {
     clerkUser,
     organization: org,
     isSignedIn: isSignedIn && !!user,
-    isLoaded: isLoaded && !!user,
+    isLoaded,
     signOut,
     feeds: feedsWithMemberships,
   };


### PR DESCRIPTION
Before, we were just using Clerk's `isSignedIn` to check if a user is auth'd before rendering certain UI. This was working across domains, however, e.g. `isSignedIn` would be true for both `org1.churchfeed.dev` and `org2.churchfeed.dev`.

Todo: 
- [ ] We should also check to see if there's a setting on the Clerk side that limits sessions to one subdomain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of user authentication status by ensuring the user is only reported as signed in when user data is fully loaded and present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->