### PR TITLE
Editor animations

### DIFF
--- a/app/components/Feed.tsx
+++ b/app/components/Feed.tsx
@@ -9,7 +9,7 @@ import { Id } from "@/convex/_generated/dataModel";
 import FeedPost from "./FeedPost";
 import FeedSkeleton from "./FeedSkeleton";
 import useViewportHeight from "@/app/hooks/useViewportHeight";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { useOrganization } from "../context/OrganizationProvider";
 import PostEditor from "./editor/PostEditor";
 import NewPostButton from "./editor/NewPostButton";
@@ -86,13 +86,15 @@ export default function Feed({ feedIdSlug }: FeedProps) {
             onClick={() => setIsNewPostOpen(!isNewPostOpen)}
           />
         )}
-        {isNewPostOpen && (
-          <PostEditor
-            isOpen={isNewPostOpen}
-            setIsOpen={setIsNewPostOpen}
-            feedId={feedId}
-          />
-        )}
+        <AnimatePresence>
+          {isNewPostOpen && (
+            <PostEditor
+              isOpen={isNewPostOpen}
+              setIsOpen={setIsNewPostOpen}
+              feedId={feedId}
+            />
+          )}
+        </AnimatePresence>
         <h2 className={styles.feedIntro}>What&apos;s happening?</h2>
         <motion.hr
           initial={{ width: 0 }}

--- a/app/components/editor/NewPostButton.module.css
+++ b/app/components/editor/NewPostButton.module.css
@@ -1,8 +1,13 @@
 .newPostButton {
+    --button-default-width: 30px;
+    --button-hover-width: 120px;
+    --button-default-top: 50px;
+    --button-editor-open-top: 0px;
+
     position: absolute;
     left: 100%;
-    top: 50px;
-    width: 30px;
+    top: var(--button-default-top);
+    width: var(--button-default-width);
     height: 40px;
     cursor: pointer;
     background-color: var(--mid);

--- a/app/components/editor/NewPostButton.module.css
+++ b/app/components/editor/NewPostButton.module.css
@@ -12,6 +12,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
 
     &:hover:not(.newPostButtonOpen) {
         width: max-content;
@@ -19,8 +20,6 @@
 
         .newPostButtonText {
             padding-left: var(--spacing2);
-            display: block;
-            color: var(--white);
         }
     }
 
@@ -30,7 +29,7 @@
     }
 
     .newPostButtonText {
-        display: none;
+        color: var(--white);
         white-space: nowrap;
     }
 
@@ -39,13 +38,6 @@
         border-left: 0;
         top: 0;
         background-color: var(--mid2);
-        
-        .borderMask {
-            position: absolute;
-            left: -1px;
-            width: 1px;
-            height: 100%;
-            background-color: var(--mid2);
-        }
+        transform: translateX(-1px);
     }
 }

--- a/app/components/editor/NewPostButton.tsx
+++ b/app/components/editor/NewPostButton.tsx
@@ -3,6 +3,8 @@
 import styles from "./NewPostButton.module.css";
 import Icon from "../common/Icon";
 import classNames from "classnames";
+import { motion, useAnimation } from "motion/react";
+import { useEffect, useState } from "react";
 
 interface NewPostButtonProps {
   isOpen: boolean;
@@ -11,9 +13,32 @@ interface NewPostButtonProps {
 
 export default function NewPostButton({ isOpen, onClick }: NewPostButtonProps) {
   const icon = isOpen ? "close" : "plus";
+  const [isHovered, setIsHovered] = useState(false);
+
+  const buttonAnimation = useAnimation();
+  const buttonTextAnimation = useAnimation();
+
+  useEffect(() => {
+    // When the editor is opened, clear hover so it doesn't persist
+    // and cause the label to flash when closing back to the plus state.
+    if (isOpen && isHovered) {
+      setIsHovered(false);
+    }
+
+    if (!isOpen && isHovered) {
+      buttonAnimation.start({ width: "120px", top: "50px" });
+      buttonTextAnimation.start({ opacity: 1, display: "block" });
+    } else if (isOpen) {
+      buttonAnimation.start({ width: "30px", top: 0 });
+      buttonTextAnimation.start({ opacity: 0, display: "none" });
+    } else {
+      buttonAnimation.start({ width: "30px", top: "50px" });
+      buttonTextAnimation.start({ opacity: 0, display: "none" });
+    }
+  }, [isOpen, isHovered]);
 
   return (
-    <button
+    <motion.button
       aria-label="New post"
       className={classNames(
         styles.newPostButton,
@@ -21,10 +46,37 @@ export default function NewPostButton({ isOpen, onClick }: NewPostButtonProps) {
       )}
       onClick={onClick}
       style={isOpen ? { zIndex: 3 } : {}}
+      onHoverStart={() => {
+        if (!isOpen) setIsHovered(true);
+      }}
+      onHoverEnd={() => setIsHovered(false)}
+      animate={buttonAnimation}
+      transition={{
+        width: {
+          type: "spring",
+          stiffness: 250,
+          damping: 20,
+          duration: 0.2,
+        },
+        top: {
+          duration: 0.1,
+        },
+      }}
     >
-      <div className={styles.borderMask} />
       <Icon name={icon} size={18} className={styles.newPostButtonIcon} />
-      <span className={styles.newPostButtonText}>New post</span>
-    </button>
+
+      {!isOpen && (
+        <motion.span
+          className={styles.newPostButtonText}
+          initial={{ display: "none" }}
+          animate={{
+            display: isHovered ? "block" : "none",
+            opacity: isHovered ? 1 : 0,
+          }}
+        >
+          New post
+        </motion.span>
+      )}
+    </motion.button>
   );
 }

--- a/app/components/editor/NewPostButton.tsx
+++ b/app/components/editor/NewPostButton.tsx
@@ -26,13 +26,22 @@ export default function NewPostButton({ isOpen, onClick }: NewPostButtonProps) {
     }
 
     if (!isOpen && isHovered) {
-      buttonAnimation.start({ width: "120px", top: "50px" });
+      buttonAnimation.start({
+        width: "var(--button-hover-width)",
+        top: "var(--button-default-top)",
+      });
       buttonTextAnimation.start({ opacity: 1, display: "block" });
     } else if (isOpen) {
-      buttonAnimation.start({ width: "30px", top: 0 });
+      buttonAnimation.start({
+        width: "var(--button-default-width)",
+        top: "var(--button-editor-open-top)",
+      });
       buttonTextAnimation.start({ opacity: 0, display: "none" });
     } else {
-      buttonAnimation.start({ width: "30px", top: "50px" });
+      buttonAnimation.start({
+        width: "var(--button-default-width)",
+        top: "var(--button-default-top)",
+      });
       buttonTextAnimation.start({ opacity: 0, display: "none" });
     }
   }, [isOpen, isHovered]);

--- a/app/components/editor/PostEditor.module.css
+++ b/app/components/editor/PostEditor.module.css
@@ -1,16 +1,22 @@
 .postEditor {
+    --editor-open-min-height: 190px;
+    --editor-open-width: 100%;
+    --editor-closed-radius: 12px;
+    --editor-open-radius: 0px;
+    
     position: absolute;
-    width: 100%;
-    height: 190px;
+    right: 0;
+    width: var(--editor-open-width);
+    min-height: var(--editor-open-min-height);
     background-color: var(--mid2);
     border: 1px solid var(--accent);
     border-radius: 12px;
-    border-top-right-radius: 0;
     padding: var(--spacing8);
     padding-bottom: var(--spacing6);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    overflow: hidden;
 }
 
 .error {

--- a/app/components/editor/PostEditor.tsx
+++ b/app/components/editor/PostEditor.tsx
@@ -12,6 +12,7 @@ import { useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { useOrganization } from "../../context/OrganizationProvider";
 import { Id } from "../../../convex/_generated/dataModel";
+import { motion } from "framer-motion";
 
 interface EditorNode {
   type: string;
@@ -90,9 +91,37 @@ export default function PostEditor({
     }
   };
 
+  const editorInitial = {
+    minHeight: 0,
+    width: 0,
+    opacity: 0,
+    borderTopRightRadius: "var(--editor-closed-radius)",
+  };
+  const editorOpen = {
+    minHeight: "var(--editor-open-min-height)",
+    width: "var(--editor-open-width)",
+    opacity: 1,
+    borderTopRightRadius: isOpen
+      ? "var(--editor-open-radius)"
+      : "var(--editor-closed-radius)",
+  };
+
   return (
     <>
-      <div className={styles.postEditor} style={isOpen ? { zIndex: 2 } : {}}>
+      <motion.div
+        className={styles.postEditor}
+        style={isOpen ? { zIndex: 2 } : {}}
+        initial={editorInitial}
+        animate={editorOpen}
+        exit={editorInitial}
+        transition={{
+          borderTopRightRadius: { duration: 0.1 },
+          duration: 0.5,
+          type: "spring",
+          stiffness: 350,
+          damping: 35,
+        }}
+      >
         {error && <div className={styles.error}>{error}</div>}
         <EditorContent editor={editor} />
         <PostEditorToolbar
@@ -100,7 +129,7 @@ export default function PostEditor({
           isPosting={isPosting}
           feedId={feedId}
         />
-      </div>
+      </motion.div>
       <Backdrop onClick={() => setIsOpen(false)} />
     </>
   );


### PR DESCRIPTION
Closes https://github.com/NolanPic/churchfeed/issues/56

Adds animations to:

- New post button hover
- New post button move to top when editor is open
- Editor opening/closing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced smooth animations when opening and closing the post editor for a more dynamic user experience.
  * Added animated hover effects to the "New Post" button, including expanding width and fading label.

* **Style**
  * Updated button and editor styles to use CSS variables for improved consistency and maintainability.
  * Enhanced visual transitions and overflow handling for the post editor and "New Post" button.

* **Refactor**
  * Simplified and modernized the handling of button and editor appearance, replacing static elements with animated transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->