### PR TITLE
New design follow-ups

### DIFF
--- a/app/components/OrganizationLayout.module.css
+++ b/app/components/OrganizationLayout.module.css
@@ -70,3 +70,27 @@
         right: var(--spacing9);
     }
 }
+
+.loginLink {
+    position: absolute;
+    top: var(--spacing9);
+    right: var(--spacing9);
+}
+
+.loginLink a {
+    color: var(--white);
+    font-size: var(--text-md);
+    transition: all 0.2s ease-in-out;
+    text-decoration: none;
+}
+
+.loginLink a:hover {
+    color: var(--accent);
+}
+
+.loginLink a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--spacing1);
+    color: var(--accent);
+}

--- a/app/components/OrganizationLayout.tsx
+++ b/app/components/OrganizationLayout.tsx
@@ -16,7 +16,7 @@ export default function OrganizationLayout({
 }) {
   const org = useOrganization();
   const pathname = usePathname();
-  const { user, isSignedIn } = useAuthedUser();
+  const { isSignedIn } = useAuthedUser();
 
   if (org === null) {
     return (
@@ -30,7 +30,7 @@ export default function OrganizationLayout({
     <>
       {pathname !== "/login" && (
         <>
-          {user && isSignedIn ? (
+          {isSignedIn ? (
             <div className={styles.userAvatarMenu}>
               <UserAvatarMenu />
             </div>

--- a/app/components/OrganizationLayout.tsx
+++ b/app/components/OrganizationLayout.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import UserAvatarMenu from "./UserAvatarMenu";
+import Link from "next/link";
 import { motion } from "motion/react";
 import { useOrganization } from "../context/OrganizationProvider";
 import { usePathname } from "next/navigation";
+import { useAuthedUser } from "@/app/hooks/useAuthedUser";
 import styles from "./OrganizationLayout.module.css";
 import Image from "next/image";
 
@@ -14,6 +16,7 @@ export default function OrganizationLayout({
 }) {
   const org = useOrganization();
   const pathname = usePathname();
+  const { user, isSignedIn } = useAuthedUser();
 
   if (org === null) {
     return (
@@ -26,9 +29,17 @@ export default function OrganizationLayout({
   return (
     <>
       {pathname !== "/login" && (
-        <div className={styles.userAvatarMenu}>
-          <UserAvatarMenu />
-        </div>
+        <>
+          {user && isSignedIn ? (
+            <div className={styles.userAvatarMenu}>
+              <UserAvatarMenu />
+            </div>
+          ) : (
+            <div className={styles.loginLink}>
+              <Link href="/login">Sign in</Link>
+            </div>
+          )}
+        </>
       )}
       <section className={styles.header}>
         <h1 className={styles.mainTitle}>{org?.name}</h1>

--- a/app/components/UserAvatarMenu.module.css
+++ b/app/components/UserAvatarMenu.module.css
@@ -1,21 +1,18 @@
 .signInLink {
     color: var(--white);
-    font-family: var(--font-gentium-plus);
     font-size: var(--text-md);
-    text-decoration-color: var(--accent);
-    text-decoration-thickness: 3px;
     transition: all 0.2s ease-in-out;
+    text-decoration: none;
 
     &:hover {
         color: var(--accent);
-        text-decoration-color: var(--white); 
     }
 
     &:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 2px;
+        border-radius: var(--spacing1);
         color: var(--accent);
-        text-decoration-color: var(--white);
     }
 }
 

--- a/app/components/UserAvatarMenu.module.css
+++ b/app/components/UserAvatarMenu.module.css
@@ -1,21 +1,3 @@
-.signInLink {
-    color: var(--white);
-    font-size: var(--text-md);
-    transition: all 0.2s ease-in-out;
-    text-decoration: none;
-
-    &:hover {
-        color: var(--accent);
-    }
-
-    &:focus-visible {
-        outline: 2px solid var(--accent);
-        outline-offset: 2px;
-        border-radius: var(--spacing1);
-        color: var(--accent);
-    }
-}
-
 .userAvatarMenuList {
     background-color: var(--mid);
     border: 1px solid var(--accent);

--- a/app/components/UserAvatarMenu.tsx
+++ b/app/components/UserAvatarMenu.tsx
@@ -2,20 +2,15 @@ import UserAvatar from "./UserAvatar";
 import { useAuthedUser } from "@/app/hooks/useAuthedUser";
 import styles from "./UserAvatarMenu.module.css";
 import { useState } from "react";
-import Link from "next/link";
 import Backdrop from "./common/Backdrop";
 import { motion, AnimatePresence } from "framer-motion";
 
 const UserAvatarMenu = () => {
-  const { user, isSignedIn, signOut } = useAuthedUser();
+  const { user, signOut } = useAuthedUser();
   const [isOpen, setIsOpen] = useState(false);
 
-  if (!user || !isSignedIn) {
-    return (
-      <Link className={styles.signInLink} href="/login">
-        Sign in
-      </Link>
-    );
+  if (!user) {
+    return null;
   }
 
   return (

--- a/app/components/common/Input.module.css
+++ b/app/components/common/Input.module.css
@@ -17,7 +17,7 @@
   padding: 0.75rem 1rem;
   border: 0;
   border-bottom: 2px solid var(--light);
-  border-radius: 2px;
+  border-radius: var(--border-radius-sm);
   font-size: var(--text-base);
   font-weight: 700;
   line-height: var(--spacing6);

--- a/app/components/common/OneTimePassword.module.css
+++ b/app/components/common/OneTimePassword.module.css
@@ -26,6 +26,19 @@
   font-weight: 700 !important;
   letter-spacing: 0.1em !important;
   padding: var(--spacing4) var(--spacing2) !important;
+  border-radius: 0;
+}
+
+.slotWrapper:first-of-type {
+  & input {
+    border-radius: var(--border-radius-sm) 0 0 var(--border-radius-sm);
+  }
+}
+
+.slotWrapper:last-of-type {
+  & input {
+    border-radius: 0 var(--border-radius-sm) var(--border-radius-sm) 0;
+  }
 }
 
 .slot label {

--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,8 @@
   --spacing23: 5.75rem;  /* 92px */
   --spacing24: 6rem;     /* 96px */
 
-  --border-radius-lg: 32px;
+  --border-radius-sm: 0.5rem;
+  --border-radius-lg: 2rem;
 }
 
 html,

--- a/app/login/page.module.css
+++ b/app/login/page.module.css
@@ -1,10 +1,5 @@
 .signinCard {
-    background-color: var(--mid);
-    border-radius: 12px;
-    max-width: calc(100% - var(--spacing8));
     margin: 0 var(--spacing4);
-    height: auto;
-    padding: var(--spacing9) var(--spacing14);
 
     form {
         width: 100%;
@@ -14,7 +9,7 @@
     }
 
     h1 {
-        font-size: var(--text-xl);
+        font-size: 2.5rem;
         font-weight: 400;
         font-family: var(--font-gentium-plus);
         text-align: center;
@@ -39,9 +34,12 @@
 
 @media (--tablet) {
     .signinCard {
+        background-color: var(--mid);
         width: 400px;
         height: 368px;
         max-width: initial;
+        border-radius: var(--border-radius-lg);
+        padding: var(--spacing9) var(--spacing14);
         margin: 0 auto;
     }
 }


### PR DESCRIPTION
Small follow-ups to https://github.com/NolanPic/churchfeed/pull/80

- Updates `<Input>` and `<OneTimePassword>` to match the design
- Cleans up the login page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Displays a “Sign in” link in the header when not signed in; shows the avatar menu only for signed-in users.

- Style
  - Updated border-radius system across the app (new small radius and adjusted large radius).
  - Refined input and one-time password field corners for a more consistent look.
  - Tweaked login page card styling and heading size; improved responsiveness on tablets.
  - Added accessible hover and focus states to the sign-in link and positioned it in the top-right.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->