### PR TITLE
Dedupe feeds

### DIFF
--- a/convex/feeds.ts
+++ b/convex/feeds.ts
@@ -1,6 +1,6 @@
-import { MutationCtx, query, QueryCtx, internalQuery } from "./_generated/server";
+import { query, QueryCtx, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
-import { Doc, Id } from "./_generated/dataModel";
+import { Id } from "./_generated/dataModel";
 import { getManyFrom, getAll } from 'convex-helpers/server/relationships';
 import { getUserAuth } from "@/auth/convex";
 
@@ -15,7 +15,15 @@ export const getUserFeeds = query({
 
     if (user) {
       const { feeds: feedsUserIsMemberOf } = await getUserFeedsWithMembershipsHelper(ctx, user._id);
-      return [...publicFeeds, ...feedsUserIsMemberOf];
+
+      const publicFeedIds = new Set(publicFeeds.map(feed => feed._id));
+
+      // Filter out feeds the user is a member of that are already in publicFeeds
+      const uniqueFeedsUserIsMemberOf = feedsUserIsMemberOf.filter(
+        feed => !publicFeedIds.has(feed._id)
+      );
+
+      return [...publicFeeds, ...uniqueFeedsUserIsMemberOf];
     } else {
       return publicFeeds;
     }


### PR DESCRIPTION
When a user is a member of a public feed, it was displaying twice in the feed selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where users could see duplicate feeds in their feed list when the same feed appeared in both public feeds and member feeds. The system now properly deduplicates these lists for a cleaner browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->