### PR TITLE
Use org host in CORS

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,6 @@
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { uploadFile } from "./uploadAction";
 
 const http = httpRouter();
@@ -11,14 +12,28 @@ http.route({
   handler: httpAction(async (ctx, request) => {
     // Check that this is a valid CORS preflight request
     const headers = request.headers;
+    const origin = headers.get("Origin");
+
     if (
-      headers.get("Origin") !== null &&
+      origin !== null &&
       headers.get("Access-Control-Request-Method") !== null &&
       headers.get("Access-Control-Request-Headers") !== null
     ) {
+      // Validate that the origin matches an organization's host
+      const { valid } = await ctx.runQuery(
+        internal.organizations.validateOrigin,
+        { origin }
+      );
+
+      if (!valid) {
+        // Origin not recognized, reject the preflight request
+        return new Response(null, { status: 403 });
+      }
+
+      // Origin is valid, return CORS headers with the specific origin
       return new Response(null, {
         headers: new Headers({
-          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Origin": origin,
           "Access-Control-Allow-Methods": "POST",
           "Access-Control-Allow-Headers": "Content-Type, Authorization",
           "Access-Control-Max-Age": "86400",

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -1,4 +1,4 @@
-import { query } from "./_generated/server";
+import { query, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 
 export const getOrganizationBySubdomain = query({
@@ -10,5 +10,49 @@ export const getOrganizationBySubdomain = query({
     return await ctx.db.query("organizations")
       .withIndex("by_host", (q) => q.eq("host", host))
       .first();
+  },
+});
+
+/**
+ * Get an organization's host by orgId
+ * Used for CORS configuration in file uploads
+ */
+export const getOrganizationHost = internalQuery({
+  args: {
+    orgId: v.id("organizations"),
+  },
+  handler: async (ctx, { orgId }) => {
+    const org = await ctx.db.get(orgId);
+    return org?.host ?? null;
+  },
+});
+
+/**
+ * Validate if a given origin matches any organization's host
+ * Used for CORS preflight validation
+ */
+export const validateOrigin = internalQuery({
+  args: {
+    origin: v.string(),
+  },
+  handler: async (ctx, { origin }) => {
+    // The origin from the browser includes the protocol (e.g., "https://subdomain.example.com")
+    // We need to extract just the host part to match against our database
+    let host: string;
+    try {
+      const url = new URL(origin);
+      host = url.host;
+    } catch {
+      return { valid: false, host: null };
+    }
+
+    const org = await ctx.db.query("organizations")
+      .withIndex("by_host", (q) => q.eq("host", host))
+      .first();
+
+    return {
+      valid: org !== null,
+      host: org?.host ?? null,
+    };
   },
 });


### PR DESCRIPTION
Replace permissive CORS policy (*) with organization-specific host validation for improved security.

Changes:
- Add getOrganizationHost query to fetch org host by orgId
- Add validateOrigin query to validate origin against org hosts
- Update OPTIONS preflight handler to validate and return specific origin
- Update uploadAction to fetch org host and use in CORS headers
- Reject unauthorized origins with 403 status

Fixes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced cross-origin request validation for file uploads. The upload feature now implements organization-specific origin verification, permitting only requests from authorized domains. Requests from unauthorized sources will be appropriately rejected to strengthen protection against unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->