### PR TITLE
fix mobile editor toolbar covered by keyboard

### DIFF
--- a/app/components/common/Modal.tsx
+++ b/app/components/common/Modal.tsx
@@ -12,6 +12,7 @@ import styles from "./Modal.module.css";
 import Icon from "./Icon";
 import { useMediaQuery } from "@/app/hooks/useMediaQuery";
 import { useLockBodyScroll } from "@/app/hooks/useLockBodyScroll";
+import { useKeyboardAwarePosition } from "@/app/hooks/useKeyboardAwarePosition";
 
 interface ModalToolbarProps {
   onClose: () => void;
@@ -56,6 +57,11 @@ export default function Modal({
   const isTabletOrUp = useMediaQuery("(min-width: 34.375rem)");
   const doAnimateDragToCloseOnPhone = !isTabletOrUp && dragToClose;
   const tabListRef = useRef<HTMLDivElement>(null);
+
+  // Estimated toolbar height: IconButton (48px) + padding (24px)
+  const toolbarHeight = 72;
+  const padding = 16;
+  const toolbarTop = useKeyboardAwarePosition(toolbarHeight) - padding;
 
   useLockBodyScroll(isOpen);
 
@@ -237,7 +243,18 @@ export default function Modal({
         </div>
       </motion.div>
       {toolbar && (
-        <div className={styles.toolbar}>
+        <div
+          className={styles.toolbar}
+          style={
+            !isTabletOrUp
+              ? {
+                  position: "absolute",
+                  top: 0,
+                  transform: `translateY(${toolbarTop}px)`,
+                }
+              : undefined
+          }
+        >
           {toolbar({ onClose: handleClose })}
         </div>
       )}

--- a/app/hooks/useKeyboardAwarePosition.ts
+++ b/app/hooks/useKeyboardAwarePosition.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Custom hook for positioning elements above the mobile keyboard using Visual Viewport API
+ * @param elementHeight - Height of the element in pixels
+ * @returns top position in pixels for use with position: absolute and transform
+ */
+export function useKeyboardAwarePosition(elementHeight: number) {
+  const [top, setTop] = useState(0);
+
+  useEffect(() => {
+    function handleResize() {
+      // Use Visual Viewport API if available, fallback to window.innerHeight
+      const viewportHeight =
+        window.visualViewport?.height ?? window.innerHeight;
+      const scrollY = window.scrollY || 0;
+
+      // Calculate position: bottom of visible viewport minus element height
+      const newTop = viewportHeight + scrollY - elementHeight;
+      setTop(newTop);
+    }
+
+    // Run on mount to set initial position
+    handleResize();
+
+    window.visualViewport?.addEventListener("resize", handleResize);
+    window.visualViewport?.addEventListener("scroll", handleResize);
+
+    // Fallback for browsers without Visual Viewport API
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.visualViewport?.removeEventListener("resize", handleResize);
+      window.visualViewport?.removeEventListener("scroll", handleResize);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [elementHeight]);
+
+  return top;
+}


### PR DESCRIPTION
Use Visual Viewport API to dynamically position the modal toolbar above the mobile keyboard when it opens. Created useKeyboardAwarePosition hook that listens to viewport resize/scroll events and calculates the correct position. Applied only to phone screens using position: absolute with transform, while tablet/desktop retain the existing fixed positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile keyboard interaction: The interface now intelligently repositions elements on mobile devices when the on-screen keyboard appears, keeping important content and toolbar visible. This enhancement improves usability when filling out forms or entering information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->