### PR TITLE
Gate feed and thread queries until auth finishes

### DIFF
--- a/app/components/content/messages/MessageThread.tsx
+++ b/app/components/content/messages/MessageThread.tsx
@@ -15,15 +15,19 @@ import Link from "next/link";
 import { motion, useMotionValue, animate } from "motion/react";
 import { useState, useEffect } from "react";
 
-export default function MessageThread({ threadId }: { threadId: Id<"threads"> }) {
+export default function MessageThread({
+  threadId,
+}: {
+  threadId: Id<"threads">;
+}) {
   const org = useOrganization();
   const orgId = org?._id as Id<"organizations">;
-  const thread = useQuery(api.threads.getById, {
-    orgId,
-    threadId,
-  });
-  const messages = useQuery(api.messages.getForThread, { orgId, threadId });
   const [auth, { isLoading: isUserLoading, user }] = useUserAuth();
+
+  const queryArgs = !isUserLoading && org?._id ? { orgId, threadId } : "skip";
+  const thread = useQuery(api.threads.getById, queryArgs);
+  const messages = useQuery(api.messages.getForThread, queryArgs);
+
   const [canSendMessage, setCanSendMessage] = useState(false);
 
   const isSignedIn = auth !== null;

--- a/app/components/content/threads/ThreadModalContent.tsx
+++ b/app/components/content/threads/ThreadModalContent.tsx
@@ -9,6 +9,7 @@ import styles from "./ThreadModalContent.module.css";
 import { useOrganization } from "@/app/context/OrganizationProvider";
 import MessageThread from "../messages/MessageThread";
 import Thread from "./Thread";
+import { useUserAuth } from "@/auth/client/useUserAuth";
 
 export default function ThreadModalContent({
   threadId,
@@ -18,10 +19,11 @@ export default function ThreadModalContent({
   onClose: () => void;
 }) {
   const org = useOrganization();
+  const [, { isLoading: isAuthLoading }] = useUserAuth();
   const { setFeedIdOfCurrentThread } = useContext(CurrentFeedAndThreadContext);
   const thread = useQuery(
     api.threads.getById,
-    org?._id ? { orgId: org._id, threadId } : "skip"
+    !isAuthLoading && org?._id ? { orgId: org._id, threadId } : "skip"
   );
 
   const feedId = thread?.feedId;

--- a/app/components/notifications/NotificationMarkAsRead.tsx
+++ b/app/components/notifications/NotificationMarkAsRead.tsx
@@ -6,12 +6,14 @@ import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useOrganization } from "@/app/context/OrganizationProvider";
 import { Id } from "@/convex/_generated/dataModel";
+import { useUserAuth } from "@/auth/client/useUserAuth";
 
 export default function NotificationMarkAsRead() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
   const org = useOrganization();
+  const [auth, { isLoading: isAuthLoading }] = useUserAuth();
   const markAsRead = useMutation(api.notifications.markNotificationAsRead);
 
   // Track if we've already processed to avoid double-calls
@@ -20,6 +22,7 @@ export default function NotificationMarkAsRead() {
   useEffect(() => {
     // Only run once
     if (hasProcessedRef.current) return;
+    if (isAuthLoading) return;
 
     const notificationId = searchParams.get("notificationId");
 
@@ -29,14 +32,16 @@ export default function NotificationMarkAsRead() {
 
     hasProcessedRef.current = true;
 
-    // Mark as read immediately (don't wait for response)
-    markAsRead({
-      orgId: org._id,
-      notificationId: notificationId as Id<"notifications">,
-    }).catch((error) => {
-      console.error("Failed to mark notification as read:", error);
-      // Don't throw - this is a non-critical operation
-    });
+    if (auth) {
+      // Mark as read immediately (don't wait for response)
+      markAsRead({
+        orgId: org._id,
+        notificationId: notificationId as Id<"notifications">,
+      }).catch((error) => {
+        console.error("Failed to mark notification as read:", error);
+        // Don't throw - this is a non-critical operation
+      });
+    }
 
     // Clean up URL (remove notificationId parameter)
     const newParams = new URLSearchParams(searchParams);
@@ -49,7 +54,7 @@ export default function NotificationMarkAsRead() {
 
     // Replace URL without triggering navigation
     router.replace(newUrl, { scroll: false });
-  }, [searchParams, org, markAsRead, router, pathname]);
+  }, [searchParams, org, auth, isAuthLoading, markAsRead, router, pathname]);
 
   // This component renders nothing
   return null;


### PR DESCRIPTION
Summary
- prevent feed and thread queries from running with stale auth by passing "skip" during `useUserAuth` loading periods in `Feed.tsx`, `ThreadModalContent.tsx`, and `MessageThread.tsx`
- stop notification mark-as-read from firing until auth settles and only when signed in, while keeping the existing URL cleanup flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state handling across the application to ensure data loading and API operations are properly gated by authentication status, preventing premature calls during login flows and improving stability for message threads, thread details, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->